### PR TITLE
🧹 Janitor: Fix use-after-free in asteroid garbage collection

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2024-05-24: Fixed use-after-free vulnerability during asteroid list garbage collection by preserving the next pointer before freeing.

--- a/src/asteroid_list.c
+++ b/src/asteroid_list.c
@@ -44,9 +44,11 @@ int blasteroids_asteroid__gc(struct Asteroid **a) {
             previous->next = this->next;
             free(this);
             destroyed++;
+            this = previous->next;
+        } else {
+            previous = this;
+            this = this->next;
         }
-        previous = this;
-        this = this->next;
     }
     if ((*a)->health <= 0) {
         struct Asteroid *dummy = (*a)->next;


### PR DESCRIPTION
### What Changed
Fixed a use-after-free vulnerability in the asteroid garbage collection logic (`blasteroids_asteroid__gc`). When freeing an asteroid node, the pointer `this` was being accessed `this = this->next` after `free(this)`. Now, we correctly advance the pointer before freeing the node.

### Why This Helps
This prevents undefined behavior, memory corruption, and potential crashes during asteroid garbage collection. It ensures the linked list iteration is safe when removing elements.

### Before/After
**Before:**
```c
if (this->health <= 0) {
    previous->next = this->next;
    free(this);
    destroyed++;
}
previous = this;
this = this->next; // use-after-free if this was freed!
```

**After:**
```c
if (this->health <= 0) {
    previous->next = this->next;
    free(this);
    destroyed++;
    this = previous->next;
} else {
    previous = this;
    this = this->next;
}
```

### Verification
- `clang-tidy` reported the use-after-free vulnerability originally.
- After the fix, running `find . -type f \( -name "*.c" -o -name "*.h" \) | xargs clang-tidy -p build` no longer reports this warning.
- The project builds successfully with `./adm build`.

### Assumptions
- The list deletion logic assumes `previous` is appropriately managed. Since `this = (*a)->next` and `previous = *a` initially, skipping the assignment of `previous` and advancing `this` using `previous->next` properly handles sequential deletions.
- The head node `*a` is handled separately at the end of the loop, which remains intact.

### Alternatives Not Chosen
- Instead of tracking `previous` explicitly, we could have used a pointer to a pointer (`struct Asteroid **this_ptr`) to simplify list traversal and deletion, but opted for the minimal fix to preserve existing code style.

### How To Pivot
- If the pointer-to-pointer approach is preferred, `blasteroids_asteroid__gc` can be refactored to use `struct Asteroid **curr = a;` and iterate using `while (*curr)`.

### Next Knobs
- `src/asteroid_list.c` -> `blasteroids_asteroid__gc`

---
*PR created automatically by Jules for task [14530271769492800156](https://jules.google.com/task/14530271769492800156) started by @lucasew*