### PR TITLE
🛡️ Sentinel: [Medium] Fix swallowed errors and silent malloc failures

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-16: [Swallowed errors and missing va_end() in variadic functions - watch out for unhandled malloc failures and incomplete va_list cleanup in centralized loggers]

--- a/main.c
+++ b/main.c
@@ -95,12 +95,14 @@ int main() {
     sp.health = 100;
     ctx.ship = sp;
     ctx.asteroids = malloc(sizeof(struct Asteroid*));
+    if (!ctx.asteroids)
+        error("Não foi possível alocar memória para asteroides.");
     *ctx.asteroids = NULL;
     blasteroids_asteroid__generate_and_append(&ctx);
     ctx.bullets = malloc(sizeof(struct Bullet*));
+    if (!ctx.bullets)
+        error("Não foi possível alocar memória para balas.");
     *ctx.bullets = NULL;
-    running = ctx.asteroids && ctx.bullets; // Se algum deles for falso/NULL, fechar o programa
-    if (!running) handle_shutdown(SIGINT);
     // Event loop in main thread
     ALLEGRO_EVENT event; // Apenas para não ter de redeclarar a cada iteração
     while(running) {

--- a/src/asteroid_list.c
+++ b/src/asteroid_list.c
@@ -17,14 +17,14 @@ void blasteroids_asteroid__append(struct Asteroid **old, struct Asteroid new) {
     if (old == NULL) return;
     if (*old == NULL) {
         *old = malloc(sizeof(struct Asteroid));
-        if (*old == NULL) return;
+        if (*old == NULL) error("Não foi possível alocar memória para novo asteroide.");
         *(*old) = new;
         (*old)->next = NULL;
         return;
     }
     struct Asteroid *newp = malloc(sizeof(struct Asteroid));
     if (newp == NULL)
-        return;
+        error("Não foi possível alocar memória para novo asteroide.");
     *newp = new;
     newp->next = *old;
     *old = newp;

--- a/src/bullet_list.c
+++ b/src/bullet_list.c
@@ -28,7 +28,7 @@ void blasteroids_bullet__append(struct Bullet **old, struct Bullet new) {
     if (*old == NULL ) {
         *old = malloc(sizeof(struct Bullet));
         if (*old == NULL) {
-            return;
+            error("Não foi possível alocar memória para nova bala.");
         }
         *(*old) = new;
         (*old)->next = NULL;
@@ -36,7 +36,7 @@ void blasteroids_bullet__append(struct Bullet **old, struct Bullet new) {
     }
     struct Bullet *newp = malloc(sizeof(struct Bullet));
     if (newp == NULL)
-        return;
+        error("Não foi possível alocar memória para nova bala.");
     *newp = new;
     newp->next = *old;
     *old = newp;

--- a/src/util_log.c
+++ b/src/util_log.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <blasteroids/config.h>
+#include <stdlib.h>
 #include <blasteroids/config.h>
 #include <blasteroids/main.h>
 #include <stdarg.h>
@@ -12,16 +13,19 @@ void debug(char *message, ...) {
     printf("DEBUG: ");
     vprintf(message, args);
     printf("\n");
+    va_end(args);
 #endif
 }
 
 void error(char *message, ...) {
     va_list args;
     va_start(args, message);
-    printf("ERRO: ");
-    vprintf(message, args);
-    printf("\n");
+    fprintf(stderr, "ERRO: ");
+    vfprintf(stderr, message, args);
+    fprintf(stderr, "\n");
+    va_end(args);
     stop(SIGTERM); // Manda fechar
+    exit(EXIT_FAILURE);
 }
 
 void info(char *message, ...) {
@@ -30,4 +34,5 @@ void info(char *message, ...) {
     printf("INFO: ");
     vprintf(message, args);
     printf("\n");
+    va_end(args);
 }


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** Ignored/swallowed errors and unhandled allocation failures (retroactive violations of the centralized error handling and fail-secure rules).
**Impact:** `malloc` failures were either silently ignored (causing elements to silently not spawn) or completely unhandled in initialization (causing the app to try running with null pointers, resulting in hard segfaults). Additionally, variadic list processing lacked `va_end()` cleanup in the logger functions, leading to undefined behavior.
**Fix:** Refactored `error()` in `src/util_log.c` to log to `stderr` and exit with `EXIT_FAILURE` immediately instead of returning. Updated initialization allocations in `main.c` and list appends in `src/asteroid_list.c` and `src/bullet_list.c` to catch `malloc` failures and route them to `error()`. Added `va_end(args)` to all variadic logging utilities. Added a journal entry to `.jules/sentinel.md`.
**Verification:** Build completes successfully with Ninja, and manual inspection confirms centralized error reporting triggers `exit(EXIT_FAILURE)` as expected.

### Assumptions
- The game is intended to fail loudly and securely (abort) when memory allocation fails, rather than attempting complex graceful degradation while game state is broken.
- Centralized errors should terminate with a non-zero exit code (`EXIT_FAILURE`).

### Alternatives Not Chosen
- Returning a boolean error flag up the call stack for the append functions (rejected because `error()` already encapsulates a safe shutdown).

### How To Pivot
If the application should attempt graceful degradation instead of a hard crash on list allocation failures, revert the `error()` calls in `src/asteroid_list.c` and `src/bullet_list.c` to their original `return;` forms (while keeping the initialization checks in `main.c` since the app cannot run without its core structures).

### Next Knobs
- The format string passed to `error()` in list appends could include runtime values (like entity size) if more context is needed.
- `src/util_log.c` could be updated to route these errors to an external service or a local crash log file if desired.

---
*PR created automatically by Jules for task [14894533950572385726](https://jules.google.com/task/14894533950572385726) started by @lucasew*