### PR TITLE
🧹 Janitor: Fix memory warnings and function prototypes

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2025-03-18: [Always balance va_start with va_end and ensure pointers are not accessed after free]

--- a/include/blasteroids/main.h
+++ b/include/blasteroids/main.h
@@ -6,7 +6,7 @@ int is_collision(GameContext *ctx);
 
 void update_states();
 
-void handle_shutdown();
+void handle_shutdown(int sig);
 
 void stop(int sig);
 

--- a/include/blasteroids/util_log.h
+++ b/include/blasteroids/util_log.h
@@ -1,10 +1,10 @@
 #ifndef _BLASTEROIDS_UTIL_LOG
 #define _BLASTEROIDS_UTIL_LOG
 
-void debug(char *message, ...);
+void debug(const char *message, ...);
 
-void error(char *message, ...);
+void error(const char *message, ...);
 
-void info(char *message, ...);
+void info(const char *message, ...);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -109,7 +109,7 @@ int main() {
     // ============= SAINDO ===========
     handle_shutdown(SIGINT);
 }
-void handle_shutdown() {
+void handle_shutdown(int sig) {
     info("Saindo....");
     /*debug("Destroy timer");
       al_destroy_timer(ctx->timer);*/

--- a/src/asteroid_list.c
+++ b/src/asteroid_list.c
@@ -42,8 +42,11 @@ int blasteroids_asteroid__gc(struct Asteroid **a) {
     while (this != NULL) {
         if (this->health <= 0) {
             previous->next = this->next;
+            struct Asteroid *next_node = this->next;
             free(this);
             destroyed++;
+            this = next_node;
+            continue;
         }
         previous = this;
         this = this->next;

--- a/src/util_log.c
+++ b/src/util_log.c
@@ -5,29 +5,34 @@
 #include <blasteroids/main.h>
 #include <stdarg.h>
 
-void debug(char *message, ...) {
+void debug(const char *message, ...) {
 #ifdef DEBUG
     va_list args;
     va_start(args, message);
     printf("DEBUG: ");
     vprintf(message, args);
     printf("\n");
+    va_end(args);
+#else
+    (void)message;
 #endif
 }
 
-void error(char *message, ...) {
+void error(const char *message, ...) {
     va_list args;
     va_start(args, message);
     printf("ERRO: ");
     vprintf(message, args);
     printf("\n");
+    va_end(args);
     stop(SIGTERM); // Manda fechar
 }
 
-void info(char *message, ...) {
+void info(const char *message, ...) {
     va_list args;
     va_start(args, message);
     printf("INFO: ");
     vprintf(message, args);
     printf("\n");
+    va_end(args);
 }


### PR DESCRIPTION
### What Changed
- Fixed `use-after-free` in `src/asteroid_list.c` by storing `this->next` before freeing `this` during the GC phase.
- Fixed uninitialized `va_list` warnings in `src/util_log.c` by ensuring `va_end(args)` is called.
- Fixed `handle_shutdown` prototype and definition to explicitly take `int sig` instead of taking empty arguments while being called with `SIGINT`.
- Added `.jules/janitor.md` to log a quick tip.

### Why This Helps
- Prevents potential memory corruption and undefined behavior caused by traversing freed pointers.
- Removes noisy compiler warnings related to missing function arguments or missing `va_end`.

### Before/After
- **Before:** `clang-tidy` found use-after-free issues and uninitialized variables in logging helpers. `handle_shutdown` lacked an argument prototype.
- **After:** `clang-tidy` warnings fixed and prototype explicitly added.

### Verification
- Compiled successfully with `cmake` and `ninja`.
- Verified changes with `clang-tidy`. No warnings related to the previously found issues remain.

### Assumptions
- The `trunk` and `mise.sh` files added to git were test artifacts during initialization and were excluded from commit.
- PR 65 is currently open and has a potential conflict with my change but I updated it so it can be overwritten or resolved via rebase.

### Alternatives Not Chosen
- Skipping `va_end` updates because `util_log.c` was partly guarded by `#ifdef DEBUG`. Added it to prevent linting tools from failing in CI when built in debug mode.

### How To Pivot
- If `use-after-free` fix in `src/asteroid_list.c` conflicts with an existing branch, only keep the prototype and `util_log.c` updates.

### Next Knobs
- Adjust `clang-tidy` rules in `.clang-tidy` to strictly fail builds on warning.

---
*PR created automatically by Jules for task [12364834660766874013](https://jules.google.com/task/12364834660766874013) started by @lucasew*