### PR TITLE
🛠️ Refactor: Replace magic numbers with named constants

### DIFF
--- a/src/bullet_draw.c
+++ b/src/bullet_draw.c
@@ -5,6 +5,16 @@
 #include <blasteroids/bullet_draw.h>
 #include <blasteroids/util_draw.h>
 
+#define BULLET_LINE_THICKNESS 2.0f
+
+static const int BULLET_LINES_COUNT = 4;
+static const float bullet_lines[][4] = {
+    {1, 0, 0, 1},
+    {0, 1, -1, 0},
+    {-1, 0, 0, -1},
+    {0, -1, 1, 0}
+};
+
 
 void blasteroids_bullet__draw(struct Bullet *b) {
     ALLEGRO_TRANSFORM t;
@@ -12,10 +22,14 @@ void blasteroids_bullet__draw(struct Bullet *b) {
     al_rotate_transform(&t, deg2rad(b->heading));
     al_translate_transform(&t, b->sx, b->sy);
     al_use_transform(&t);
-    al_draw_line(1, 0, 0, 1, b->color, 2.0f);
-    al_draw_line(0, 1, -1, 0, b->color, 2.0f);
-    al_draw_line(-1, 0, 0, -1, b->color, 2.0f);
-    al_draw_line(0, -1, 1, 0, b->color, 2.0f);
+
+    for (int i = 0; i < BULLET_LINES_COUNT; i++) {
+        al_draw_line(
+            bullet_lines[i][0], bullet_lines[i][1],
+            bullet_lines[i][2], bullet_lines[i][3],
+            b->color, BULLET_LINE_THICKNESS
+        );
+    }
 }
 
 void blasteroids_bullet__draw_all(struct Bullet **b) {

--- a/src/bullet_generator.c
+++ b/src/bullet_generator.c
@@ -3,14 +3,16 @@
 #include <blasteroids/spaceship_struct.h>
 #include <blasteroids/util_rand.h>
 
+#define BULLET_SPEED_MAX 100
+#define BULLET_POWER_MAX 50
 
 struct Bullet blasteroids_bullet__generate(struct Spaceship sp) {
     Bullet bt;
     bt.sx = sp.sx;
     bt.sy = sp.sy;
     bt.heading = sp.heading;
-    bt.speed = 1 + randomize(100);
-    bt.power = 1 + randomize(50);
+    bt.speed = 1 + randomize(BULLET_SPEED_MAX);
+    bt.power = 1 + randomize(BULLET_POWER_MAX);
     bt.color = blasteroids_rand_color();
     bt.next = NULL;
     return bt;

--- a/src/collision.c
+++ b/src/collision.c
@@ -8,6 +8,9 @@
 #include <blasteroids/bullet_struct.h>
 #include <blasteroids/bullet_list.h>
 
+#define SPACESHIP_COLLISION_RADIUS 10
+#define ASTEROID_COLLISION_RADIUS_BASE 22
+
 int blasteroids_check_collision_asteroid_spaceship(GameContext *ctx) {
     int collisions = 0;
     if (ctx->asteroids == NULL) return 0;
@@ -23,7 +26,7 @@ int blasteroids_check_collision_asteroid_spaceship(GameContext *ctx) {
         ax = this->sx;
         ay = this->sy;
         cur_distance = blasteroids_get_distance(sx, sy, ax, ay);
-        min_distance = 10 + 22*this->scale;
+        min_distance = SPACESHIP_COLLISION_RADIUS + ASTEROID_COLLISION_RADIUS_BASE*this->scale;
 #ifdef DEBUG_COLLISION_GRAPH
         // Linha entre o asteroide e a nave
         ALLEGRO_TRANSFORM t;
@@ -57,7 +60,7 @@ int blasteroids_check_collision_asteroid_bullet(GameContext *ctx) {
     while (bu != NULL) {
         while (as != NULL) {
             distancia = blasteroids_get_distance(as->sx, as->sy, bu->sx, bu->sy);
-            if (distancia < (22*as->scale)) {
+            if (distancia < (ASTEROID_COLLISION_RADIUS_BASE*as->scale)) {
                 ctx->score = ctx->score + bu->power;
                 as->health = as->health - bu->power;
                 struct Bullet *dummy = bu->next;

--- a/src/event.c
+++ b/src/event.c
@@ -11,6 +11,8 @@
 #include <blasteroids/spaceship_ops.h>
 #include <blasteroids/util_log.h>
 
+#define SECONDS_PER_MINUTE 60
+#define ASTEROID_GENERATION_INTERVAL 10
 
 void event_loop_once(GameContext *ctx, ALLEGRO_EVENT *event) {
     al_wait_for_event(ctx->event_queue, event);
@@ -21,7 +23,7 @@ void game_over(GameContext *ctx) {
     printf("========== GAME OVER ==========\n");
     printf("Você morreu :c.\n");
     printf("Você conseguiu %i pontos.\n", ctx->score);
-    printf("Tempo de jogo: %i min %i s\n", ctx->HearthBeat/(60*FPS), (ctx->HearthBeat/FPS)%60);
+    printf("Tempo de jogo: %i min %i s\n", ctx->HearthBeat/(SECONDS_PER_MINUTE*FPS), (ctx->HearthBeat/FPS)%SECONDS_PER_MINUTE);
     printf("===============================\n");
     fflush(stdout);
     handle_shutdown(SIGINT); // Finalizando o jogo
@@ -63,7 +65,7 @@ void handle_event(ALLEGRO_EVENT *ev, GameContext *ctx) {
     if(ev->type == ALLEGRO_EVENT_TIMER) {
         ctx->HearthBeat = ctx->HearthBeat + 1;
         blasteroids_context__tick(ctx);
-        if (!(ctx->HearthBeat%(10*FPS)))
+        if (!(ctx->HearthBeat%(ASTEROID_GENERATION_INTERVAL*FPS)))
             blasteroids_asteroid__generate_and_append(ctx);
     }
     if(ev->type == ALLEGRO_EVENT_DISPLAY_CLOSE) {

--- a/src/spaceship_draw.c
+++ b/src/spaceship_draw.c
@@ -2,16 +2,30 @@
 #include <allegro5/allegro_primitives.h>
 #include <blasteroids/util_draw.h>
 
+#define SPACESHIP_LINE_THICKNESS 3.0f
+
+static const int SPACESHIP_LINES_COUNT = 4;
+static const float spaceship_lines[][4] = {
+    {-8, 9, 0, -11},
+    {0, -11, 8, 9},
+    {-6, 4, -1, 4},
+    {6, 4, 1, 4}
+};
+
 void blasteroids_ship__draw(Spaceship s) {
     ALLEGRO_TRANSFORM transform;
     al_identity_transform(&transform);
     al_rotate_transform(&transform, deg2rad(s.heading));
     al_translate_transform(&transform, s.sx, s.sy);
     al_use_transform(&transform);
-    al_draw_line(-8, 9, 0, -11, s.color, 3.0f);
-    al_draw_line(0, -11, 8, 9, s.color, 3.0f);
-    al_draw_line(-6, 4, -1, 4, s.color, 3.0f);
-    al_draw_line(6, 4, 1, 4, s.color, 3.0f);
+
+    for (int i = 0; i < SPACESHIP_LINES_COUNT; i++) {
+        al_draw_line(
+            spaceship_lines[i][0], spaceship_lines[i][1],
+            spaceship_lines[i][2], spaceship_lines[i][3],
+            s.color, SPACESHIP_LINE_THICKNESS
+        );
+    }
 }
 
 

--- a/src/text_draw.c
+++ b/src/text_draw.c
@@ -4,23 +4,29 @@
 
 #include <blasteroids/text_draw.h>
 
+#define COLOR_BLUE al_map_rgb(0, 0, 255)
+#define COLOR_WHITE al_map_rgb(255, 255, 255)
+#define COLOR_GREEN al_map_rgb(0, 255, 0)
+#define TEXT_PADDING_X 10
+#define TEXT_PADDING_Y 10
+
 void blasteroids_life__draw(GameContext *ctx) {
     ALLEGRO_TRANSFORM t;
     al_identity_transform(&t);
     al_use_transform(&t);
-    al_draw_textf(ctx->font, al_map_rgb(0, 0, 255), 10, 10, ALLEGRO_ALIGN_LEFT, "<3 %i", ctx->ship.health);
+    al_draw_textf(ctx->font, COLOR_BLUE, TEXT_PADDING_X, TEXT_PADDING_Y, ALLEGRO_ALIGN_LEFT, "<3 %i", ctx->ship.health);
 }
 
 void blasteroids_counter__draw(GameContext *ctx) {
     ALLEGRO_TRANSFORM t;
     al_identity_transform(&t);
     al_use_transform(&t);
-    al_draw_textf(ctx->font, al_map_rgb(255, 255, 255), blasteroids_display__w(ctx)/3, 10, ALLEGRO_ALIGN_RIGHT, "C: %i", ctx->HearthBeat);
+    al_draw_textf(ctx->font, COLOR_WHITE, blasteroids_display__w(ctx)/3, TEXT_PADDING_Y, ALLEGRO_ALIGN_RIGHT, "C: %i", ctx->HearthBeat);
 }
 
 void blasteroids_score__draw(GameContext *ctx) {
     ALLEGRO_TRANSFORM t;
     al_identity_transform(&t);
     al_use_transform(&t);
-    al_draw_textf(ctx->font, al_map_rgb(0, 255, 0), 2*blasteroids_display__w(ctx)/3, 10, ALLEGRO_ALIGN_RIGHT, "PTS: %i", ctx->score);
+    al_draw_textf(ctx->font, COLOR_GREEN, 2*blasteroids_display__w(ctx)/3, TEXT_PADDING_Y, ALLEGRO_ALIGN_RIGHT, "PTS: %i", ctx->score);
 }

--- a/src/util_draw.c
+++ b/src/util_draw.c
@@ -2,8 +2,10 @@
 #include <blasteroids/config.h>
 #include <blasteroids/util_draw.h>
 
+#define DEG2RAD_CONSTANT 0.0174532925f
+
 float deg2rad(float deg) {
-    return 0.0174532925 * deg;
+    return DEG2RAD_CONSTANT * deg;
 }
 
 float blasteroids_get_delta_x(float speed, float degrees) {


### PR DESCRIPTION
I've replaced various magic numbers across the codebase with specific named constants as part of the refactoring strategy to reduce complexity, which aligns with Martin Fowler's "Magic Numbers" code smell definition.

Changes include:
- `SPACESHIP_LINE_THICKNESS` and `BULLET_LINE_THICKNESS` definitions.
- Line coordinates extracted to isolated arrays to avoid multiple explicit literal parameters, reducing boilerplate in line drawing calls.
- Constants for asteroid generator speed, power limitations, etc.
- Extracted colors to explicit constants.

No behavioral changes were introduced. Behavior parity was manually verified via compilation and review.

### Assumptions
- Collision logic constraints (`10`, `22` multipliers) were intended to scale based on basic geometric collision radius logic, so they were extracted explicitly as `ASTEROID_COLLISION_RADIUS_BASE` and `SPACESHIP_COLLISION_RADIUS`.

### Alternatives Not Chosen
- Introducing an external configuration file: Considered to allow user-side modifications, but decided against it to avoid scope creep for this basic refactor task.

### How To Pivot
- If these numbers are actually meant to dynamically vary per level later, replace `#define`s with struct parameters in contexts or separate configuration loaders.

### Next Knobs
- Adjusting line thickness per weapon type.
- Fine-tuning the collision radii constants if the bounding box mechanics are changed later.

---
*PR created automatically by Jules for task [17707980571600533260](https://jules.google.com/task/17707980571600533260) started by @lucasew*